### PR TITLE
Added find-by-uuid to task-repository

### DIFF
--- a/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
@@ -38,6 +38,19 @@ class ArrayTaskRepository implements TaskRepositoryInterface
     /**
      * {@inheritdoc}
      */
+    public function findByUuid($uuid)
+    {
+        /** @var TaskInterface $task */
+        foreach ($this->taskCollection as $task) {
+            if ($task->getUuid() === $uuid) {
+                return $task;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function create($handlerClass, $workload = null)
     {
         return new Task($handlerClass, $workload);

--- a/src/Task/Storage/TaskRepositoryInterface.php
+++ b/src/Task/Storage/TaskRepositoryInterface.php
@@ -19,6 +19,15 @@ use Task\TaskInterface;
 interface TaskRepositoryInterface
 {
     /**
+     * Find task for given uuid.
+     *
+     * @param string $uuid
+     *
+     * @return TaskInterface
+     */
+    public function findByUuid($uuid);
+
+    /**
      * Create task.
      *
      * @param string $handlerClass

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
@@ -24,6 +24,32 @@ use Task\TaskInterface;
  */
 class ArrayTaskRepositoryTest extends \PHPUnit_Framework_TestCase
 {
+    public function testFindByUuid()
+    {
+        $tasks = [
+            new Task(\stdClass::class, 'Test 1', '123-123-123'),
+            new Task(\stdClass::class, 'Test 2'),
+            new Task(\stdClass::class, 'Test 3'),
+        ];
+
+        $repository = new ArrayTaskRepository(new ArrayCollection($tasks));
+
+        $this->assertEquals($tasks[0], $repository->findByUuid('123-123-123'));
+    }
+
+    public function testFindByUuidNotExisting()
+    {
+        $tasks = [
+            new Task(\stdClass::class, 'Test 1'),
+            new Task(\stdClass::class, 'Test 2'),
+            new Task(\stdClass::class, 'Test 3'),
+        ];
+
+        $repository = new ArrayTaskRepository(new ArrayCollection($tasks));
+
+        $this->assertNull($repository->findByUuid('123-123-123'));
+    }
+
     public function testPersist()
     {
         $collection = $this->prophesize(Collection::class);


### PR DESCRIPTION
This PR adds the function `findByUuid` to the repository.