### PR TITLE
Removed flush of repositories

### DIFF
--- a/src/Task/Runner/TaskRunner.php
+++ b/src/Task/Runner/TaskRunner.php
@@ -99,7 +99,5 @@ class TaskRunner implements TaskRunnerInterface
                 new TaskExecutionEvent($execution->getTask(), $execution)
             );
         }
-
-        $this->taskExecutionRepository->flush();
     }
 }

--- a/src/Task/Scheduler/TaskScheduler.php
+++ b/src/Task/Scheduler/TaskScheduler.php
@@ -79,11 +79,8 @@ class TaskScheduler implements TaskSchedulerInterface
     {
         $this->eventDispatcher->dispatch(Events::TASK_CREATE, new TaskEvent($task));
 
-        $this->taskRepository->persist($task);
-        $this->taskRepository->flush();
-
+        $this->taskRepository->save($task);
         $this->scheduleTask($task);
-        $this->taskExecutionRepository->flush();
 
         return $this;
     }
@@ -97,8 +94,6 @@ class TaskScheduler implements TaskSchedulerInterface
         foreach ($tasks as $task) {
             $this->scheduleTask($task);
         }
-
-        $this->taskExecutionRepository->flush();
     }
 
     /**
@@ -119,7 +114,7 @@ class TaskScheduler implements TaskSchedulerInterface
                 new TaskExecutionEvent($task, $execution)
             );
 
-            $this->taskExecutionRepository->persist($execution);
+            $this->taskExecutionRepository->save($execution);
         }
     }
 }

--- a/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
@@ -48,7 +48,7 @@ class ArrayTaskExecutionRepository implements TaskExecutionRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function persist(TaskExecutionInterface $execution)
+    public function save(TaskExecutionInterface $execution)
     {
         $this->taskExecutionCollection->add($execution);
 

--- a/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
@@ -59,7 +59,7 @@ class ArrayTaskRepository implements TaskRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function persist(TaskInterface $task)
+    public function save(TaskInterface $task)
     {
         $this->taskCollection->add($task);
 

--- a/src/Task/Storage/TaskExecutionRepositoryInterface.php
+++ b/src/Task/Storage/TaskExecutionRepositoryInterface.php
@@ -30,13 +30,13 @@ interface TaskExecutionRepositoryInterface
     public function create(TaskInterface $task, \DateTime $scheduleTime);
 
     /**
-     * Persist task-execution.
+     * Save task-execution.
      *
      * @param TaskExecutionInterface $execution
      *
      * @return $this
      */
-    public function persist(TaskExecutionInterface $execution);
+    public function save(TaskExecutionInterface $execution);
 
     /**
      * Remove task-execution.
@@ -46,13 +46,6 @@ interface TaskExecutionRepositoryInterface
      * @return $this
      */
     public function remove(TaskExecutionInterface $execution);
-
-    /**
-     * Flush storage.
-     *
-     * @return $this
-     */
-    public function flush();
 
     /**
      * Used to check whether a specific task has been scheduled at a specific time.

--- a/src/Task/Storage/TaskRepositoryInterface.php
+++ b/src/Task/Storage/TaskRepositoryInterface.php
@@ -38,25 +38,18 @@ interface TaskRepositoryInterface
     public function create($handlerClass, $workload = null);
 
     /**
-     * Persist task.
+     * Save task.
      *
      * @param TaskInterface $task
      */
-    public function persist(TaskInterface $task);
+    public function save(TaskInterface $task);
 
     /**
-     * Persist task.
+     * Remove task.
      *
      * @param TaskInterface $task
      */
     public function remove(TaskInterface $task);
-
-    /**
-     * Flush storage.
-     *
-     * @return $this
-     */
-    public function flush();
 
     /**
      * Returns all tasks.

--- a/tests/Unit/Runner/TaskRunnerTest.php
+++ b/tests/Unit/Runner/TaskRunnerTest.php
@@ -76,8 +76,6 @@ class TaskRunnerTest extends \PHPUnit_Framework_TestCase
         $this->initializeDispatcher($this->eventDispatcher, $executions[0]);
         $this->initializeDispatcher($this->eventDispatcher, $executions[1]);
 
-        $this->taskExecutionRepository->flush()->shouldBeCalledTimes(1);
-
         $this->taskRunner->runTasks();
 
         $this->assertLessThanOrEqual(new \DateTime(), $executions[0]->getStartTime());
@@ -110,8 +108,6 @@ class TaskRunnerTest extends \PHPUnit_Framework_TestCase
 
         $this->initializeDispatcher($this->eventDispatcher, $executions[0], Events::TASK_FAILED);
         $this->initializeDispatcher($this->eventDispatcher, $executions[1]);
-
-        $this->taskExecutionRepository->flush()->shouldBeCalled();
 
         $this->taskRunner->runTasks();
 

--- a/tests/Unit/Scheduler/TaskSchedulerTest.php
+++ b/tests/Unit/Scheduler/TaskSchedulerTest.php
@@ -111,13 +111,11 @@ class TaskSchedulerTest extends \PHPUnit_Framework_TestCase
             )
         )->shouldBeCalled();
 
-        $this->taskRepository->persist($task->reveal())->shouldBeCalled();
-        $this->taskRepository->flush()->shouldBeCalledTimes(1);
+        $this->taskRepository->save($task->reveal())->shouldBeCalled();
 
         $this->taskExecutionRepository->findByStartTime($task, Argument::type(\DateTime::class))->willReturn(null);
         $this->taskExecutionRepository->create($task, Argument::type(\DateTime::class))->willReturn($execution);
-        $this->taskExecutionRepository->persist($execution->reveal())->shouldBeCalledTimes(1);
-        $this->taskExecutionRepository->flush()->shouldBeCalledTimes(1);
+        $this->taskExecutionRepository->save($execution->reveal())->shouldBeCalledTimes(1);
 
         $this->taskScheduler->addTask($task->reveal());
     }
@@ -145,13 +143,12 @@ class TaskSchedulerTest extends \PHPUnit_Framework_TestCase
         $this->taskExecutionRepository->create($tasks[1], $expression2->getNextRunDate())->willReturn(
             $execution1->reveal()
         );
-        $this->taskExecutionRepository->persist($execution1)->shouldBeCalled();
-        $this->taskExecutionRepository->flush()->shouldBeCalledTimes(1);
+        $this->taskExecutionRepository->save($execution1)->shouldBeCalled();
 
         $execution2 = $this->prophesize(TaskExecutionInterface::class);
         $execution2->setStatus(TaskStatus::PLANNED)->shouldBeCalled();
         $this->taskExecutionRepository->create($tasks[2], $date)->willReturn($execution2->reveal());
-        $this->taskExecutionRepository->persist($execution2)->shouldBeCalled();
+        $this->taskExecutionRepository->save($execution2)->shouldBeCalled();
 
         $this->eventDispatcher->dispatch(
             Events::TASK_EXECUTION_CREATE,

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
@@ -13,7 +13,6 @@ namespace Task\Tests\Unit\Storage\ArrayStorage;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Prophecy\Argument;
 use Task\Execution\TaskExecution;
 use Task\Execution\TaskExecutionInterface;
 use Task\Storage\ArrayStorage\ArrayTaskExecutionRepository;
@@ -25,7 +24,7 @@ use Task\TaskStatus;
  */
 class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testPersist()
+    public function testSave()
     {
         $taskExecutionCollection = $this->prophesize(Collection::class);
         $taskExecutionRepository = new ArrayTaskExecutionRepository($taskExecutionCollection->reveal());
@@ -36,7 +35,7 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $taskExecutionRepository,
-            $taskExecutionRepository->persist($execution->reveal())
+            $taskExecutionRepository->save($execution->reveal())
         );
     }
 
@@ -53,16 +52,6 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
             $taskExecutionRepository,
             $taskExecutionRepository->remove($execution->reveal())
         );
-    }
-
-    public function testFlush()
-    {
-        $taskExecutionCollection = $this->prophesize(Collection::class);
-        $taskExecutionRepository = new ArrayTaskExecutionRepository($taskExecutionCollection->reveal());
-
-        $taskExecutionCollection->add(Argument::any())->shouldNotBeCalled();
-
-        $this->assertEquals($taskExecutionRepository, $taskExecutionRepository->flush());
     }
 
     public function testFindByStartTime()

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
@@ -14,7 +14,6 @@ namespace Task\Tests\Unit\Storage\ArrayStorage;
 use Cron\CronExpression;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Prophecy\Argument;
 use Task\Storage\ArrayStorage\ArrayTaskRepository;
 use Task\Task;
 use Task\TaskInterface;
@@ -50,7 +49,7 @@ class ArrayTaskRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($repository->findByUuid('123-123-123'));
     }
 
-    public function testPersist()
+    public function testSave()
     {
         $collection = $this->prophesize(Collection::class);
         $repository = new ArrayTaskRepository($collection->reveal());
@@ -61,7 +60,7 @@ class ArrayTaskRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             $repository,
-            $repository->persist($task->reveal())
+            $repository->save($task->reveal())
         );
     }
 
@@ -78,16 +77,6 @@ class ArrayTaskRepositoryTest extends \PHPUnit_Framework_TestCase
             $repository,
             $repository->remove($task->reveal())
         );
-    }
-
-    public function testFlush()
-    {
-        $collection = $this->prophesize(Collection::class);
-        $repository = new ArrayTaskRepository($collection->reveal());
-
-        $collection->add(Argument::any())->shouldNotBeCalled();
-
-        $this->assertEquals($repository, $repository->flush());
     }
 
     public function testFindAll()


### PR DESCRIPTION
This PR removes the `flush` method from the repository. Until now the "user" has to be aware that the changes will be persisted.