### PR TITLE
Fixed save same entity in array-storage

### DIFF
--- a/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
@@ -50,6 +50,10 @@ class ArrayTaskExecutionRepository implements TaskExecutionRepositoryInterface
      */
     public function save(TaskExecutionInterface $execution)
     {
+        if ($this->taskExecutionCollection->contains($execution)) {
+            return $this;
+        }
+
         $this->taskExecutionCollection->add($execution);
 
         return $this;

--- a/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskRepository.php
@@ -61,6 +61,10 @@ class ArrayTaskRepository implements TaskRepositoryInterface
      */
     public function save(TaskInterface $task)
     {
+        if ($this->taskCollection->contains($task)) {
+            return $this;
+        }
+
         $this->taskCollection->add($task);
 
         return $this;

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
@@ -31,7 +31,24 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $execution = $this->prophesize(TaskExecutionInterface::class);
 
+        $taskExecutionCollection->contains($execution->reveal())->willReturn(false);
         $taskExecutionCollection->add($execution->reveal())->shouldBeCalled();
+
+        $this->assertEquals(
+            $taskExecutionRepository,
+            $taskExecutionRepository->save($execution->reveal())
+        );
+    }
+
+    public function testSaveExisting()
+    {
+        $taskExecutionCollection = $this->prophesize(Collection::class);
+        $taskExecutionRepository = new ArrayTaskExecutionRepository($taskExecutionCollection->reveal());
+
+        $execution = $this->prophesize(TaskExecutionInterface::class);
+
+        $taskExecutionCollection->contains($execution->reveal())->willReturn(true);
+        $taskExecutionCollection->add($execution->reveal())->shouldNotBeCalled();
 
         $this->assertEquals(
             $taskExecutionRepository,

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskRepositoryTest.php
@@ -56,7 +56,24 @@ class ArrayTaskRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $task = $this->prophesize(TaskInterface::class);
 
+        $collection->contains($task->reveal())->willReturn(false);
         $collection->add($task->reveal())->shouldBeCalled();
+
+        $this->assertEquals(
+            $repository,
+            $repository->save($task->reveal())
+        );
+    }
+
+    public function testSaveExisting()
+    {
+        $collection = $this->prophesize(Collection::class);
+        $repository = new ArrayTaskRepository($collection->reveal());
+
+        $task = $this->prophesize(TaskInterface::class);
+
+        $collection->contains($task->reveal())->willReturn(true);
+        $collection->add($task->reveal())->shouldNotBeCalled();
 
         $this->assertEquals(
             $repository,


### PR DESCRIPTION
This PR fixes a bug in the array-storage when saving an existing task-execution.