### PR TITLE
Refind execution after handle run and added task-after event

### DIFF
--- a/src/Task/Event/Events.php
+++ b/src/Task/Event/Events.php
@@ -34,6 +34,11 @@ final class Events
     const TASK_BEFORE = 'tasks.before';
 
     /**
+     * Emitted when task will be started.
+     */
+    const TASK_AFTER = 'tasks.after';
+
+    /**
      * Emitted when after task finished.
      */
     const TASK_FINISHED = 'tasks.finished';

--- a/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
+++ b/src/Task/Storage/ArrayStorage/ArrayTaskExecutionRepository.php
@@ -99,6 +99,24 @@ class ArrayTaskExecutionRepository implements TaskExecutionRepositoryInterface
     /**
      * {@inheritdoc}
      */
+    public function findByUuid($uuid)
+    {
+        $filtered = $this->taskExecutionCollection->filter(
+            function (TaskExecutionInterface $execution) use ($uuid) {
+                return $execution->getUuid() === $uuid;
+            }
+        );
+
+        if ($filtered->count() === 0) {
+            return;
+        }
+
+        return $filtered->first();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findByTask(TaskInterface $task)
     {
         return $this->findByTaskUuid($task->getUuid());

--- a/src/Task/Storage/TaskExecutionRepositoryInterface.php
+++ b/src/Task/Storage/TaskExecutionRepositoryInterface.php
@@ -57,6 +57,15 @@ interface TaskExecutionRepositoryInterface
     public function findPending(TaskInterface $task);
 
     /**
+     * Returns task-execution identified by uuid.
+     *
+     * @param string $uuid
+     *
+     * @return TaskExecutionInterface
+     */
+    public function findByUuid($uuid);
+
+    /**
      * Find executions of given task.
      *
      * @param TaskInterface $task

--- a/tests/Unit/Runner/TaskRunnerTest.php
+++ b/tests/Unit/Runner/TaskRunnerTest.php
@@ -144,6 +144,14 @@ class TaskRunnerTest extends \PHPUnit_Framework_TestCase
         )->will(
             function () use ($eventDispatcher, $execution, $event) {
                 $eventDispatcher->dispatch(
+                    Events::TASK_AFTER,
+                    Argument::that(
+                        function (TaskExecutionEvent $event) use ($execution) {
+                            return $event->getTaskExecution() === $execution;
+                        }
+                    )
+                )->shouldBeCalled();
+                $eventDispatcher->dispatch(
                     $event,
                     Argument::that(
                         function (TaskExecutionEvent $event) use ($execution) {
@@ -176,7 +184,11 @@ class TaskRunnerTest extends \PHPUnit_Framework_TestCase
         $workload = 'Test-Workload',
         $handlerClass = TestHandler::class
     ) {
-        return new TaskExecution($task, $handlerClass, $scheduleTime, $workload);
+        $execution = new TaskExecution($task, $handlerClass, $scheduleTime, $workload);
+
+        $this->taskExecutionRepository->findByUuid($execution->getUuid())->willReturn($execution);
+
+        return $execution;
     }
 }
 

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
@@ -105,6 +105,20 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([$executions[1]], $repository->findByTask($task2));
     }
 
+    public function testFindByUuid()
+    {
+        $task1 = new Task(\stdClass::class, 'Test 1', '123-123-123');
+        $executions = [
+            new TaskExecution($task1, \stdClass::class, new \DateTime('+1 day'), 'Test 1', '123-123-123'),
+            new TaskExecution($task1, \stdClass::class, new \DateTime('1 day ago'), 'Test 1'),
+            new TaskExecution($task1, \stdClass::class, new \DateTime('1 hour ago'), 'Test 1'),
+        ];
+
+        $repository = new ArrayTaskExecutionRepository(new ArrayCollection($executions));
+
+        $this->assertEquals($executions[0], $repository->findByUuid('123-123-123'));
+    }
+
     public function testFindByTaskUuid()
     {
         $task1 = new Task(\stdClass::class, 'Test 1', '123-123-123');


### PR DESCRIPTION
If an exception occurs in handler or he clears the storage manager (like entityManager in doctrine) the taskRunner should be able to save the entity although.

For example (with doctrine):

* execution will be loaded
* handler runs
   - it fails in the middle and has already a few persisted (maybe half entities)
   - it clears the enetityManager
* TASK_AFTER event will be thrown (new step)
    - EventListener in TaskBundle can clear entityManager
* execution will be found by execution (new step)
* execution updated (completed, duration, ...)

Without these new steps the entityManager will throw an error because of the unknown execution entity-object.