### PR TITLE
Added aborted status to execution

### DIFF
--- a/src/Task/Builder/TaskBuilder.php
+++ b/src/Task/Builder/TaskBuilder.php
@@ -23,12 +23,12 @@ class TaskBuilder implements TaskBuilderInterface
     /**
      * @var TaskInterface
      */
-    private $task;
+    protected $task;
 
     /**
      * @var TaskSchedulerInterface
      */
-    private $taskScheduler;
+    protected $taskScheduler;
 
     /**
      * @param TaskInterface $task

--- a/src/Task/TaskStatus.php
+++ b/src/Task/TaskStatus.php
@@ -19,6 +19,7 @@ final class TaskStatus
     const PLANNED = 'planned';
     const RUNNING = 'running';
     const COMPLETED = 'completed';
+    const ABORTED = 'aborted';
     const FAILED = 'failed';
 
     /**

--- a/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayTaskExecutionRepositoryTest.php
@@ -146,7 +146,7 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
 
         $executions[0]->setStatus(TaskStatus::COMPLETED);
         $executions[1]->setStatus(TaskStatus::FAILED);
-        $executions[2]->setStatus(TaskStatus::COMPLETED);
+        $executions[2]->setStatus(TaskStatus::ABORTED);
 
         $repository = new ArrayTaskExecutionRepository(new ArrayCollection($executions));
 
@@ -160,16 +160,17 @@ class ArrayTaskExecutionRepositoryTest extends \PHPUnit_Framework_TestCase
             new TaskExecution($task, \stdClass::class, new \DateTime('+1 day'), 'Test 1'),
             new TaskExecution($task, \stdClass::class, new \DateTime('+1 minute'), 'Test 1'),
             new TaskExecution($task, \stdClass::class, new \DateTime('+1 hour'), 'Test 1'),
+            new TaskExecution($task, \stdClass::class, new \DateTime('+1 hour'), 'Test 1'),
         ];
 
-        foreach ($executions as $execution) {
-            $execution->setStatus(TaskStatus::COMPLETED);
-        }
-        $executions[2]->setStatus(TaskStatus::PLANNED);
+        $executions[0]->setStatus(TaskStatus::COMPLETED);
+        $executions[1]->setStatus(TaskStatus::FAILED);
+        $executions[2]->setStatus(TaskStatus::ABORTED);
+        $executions[3]->setStatus(TaskStatus::PLANNED);
 
         $repository = new ArrayTaskExecutionRepository(new ArrayCollection($executions));
 
-        $this->assertEquals($executions[2], $repository->findPending($task));
+        $this->assertEquals($executions[3], $repository->findPending($task));
     }
 
     public function testFindPendingStarted()


### PR DESCRIPTION
This PR introduces a new `aborted` status for executions. This can be used when the execution should not be called anymore (for any reason)