### PR TITLE
Fix task execution status update not saved

### DIFF
--- a/src/Task/Runner/TaskRunner.php
+++ b/src/Task/Runner/TaskRunner.php
@@ -163,6 +163,8 @@ class TaskRunner implements TaskRunnerInterface
             new TaskExecutionEvent($execution->getTask(), $execution)
         );
 
+        $this->taskExecutionRepository->save($execution);
+
         return $execution;
     }
 
@@ -186,6 +188,8 @@ class TaskRunner implements TaskRunnerInterface
             Events::TASK_FAILED,
             new TaskExecutionEvent($execution->getTask(), $execution)
         );
+
+        $this->taskExecutionRepository->save($execution);
 
         return $execution;
     }


### PR DESCRIPTION
This PR fixes passed and failed status not persisted correctly in some circumstances.

This may occur, for example, if you use Doctrine as persistent storage and you globally set the Query::HINT_REFRESH query hint to true. In https://github.com/php-task/php-task/blob/4aca1efe5729b180f62615652c5f2e2ace7b9050/src/Task/Runner/TaskRunner.php#L203 a fresh entry from the database is fetched and it has the previous 'running' status.